### PR TITLE
KB-9962 | BE|DEV| Flink Job enhancements to update the certificate count to the redis

### DIFF
--- a/credential-generator/collection-certificate-generator/src/main/resources/collection-certificate-generator.conf
+++ b/credential-generator/collection-certificate-generator/src/main/resources/collection-certificate-generator.conf
@@ -34,3 +34,9 @@ lms-cassandra {
 enable.suppress.exception = true
 enable.rc.certificate = true
 specialEventCertificateName = "RepublicDay_2025"
+
+redis {
+  database {
+   certificateCountCache.id = 0
+  }
+}

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
@@ -21,7 +21,7 @@ class CertificateGenerationCompletionProcessorFn(config: CertificateGeneratorCon
   override def open(parameters: Configuration): Unit = {
     super.open(parameters)
     val redisConnect = new RedisConnect(config)
-    dataCache = new DataCache(config, redisConnect, 0, List())
+    dataCache = new DataCache(config, redisConnect, config.cacheDbId, List())
     dataCache.init()
     cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort)
     logger.info("CertificateGenerationCompletionProcessorFn: Redis connection initialized")

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
@@ -1,0 +1,104 @@
+package org.sunbird.job.certgen.functions
+
+import com.datastax.driver.core.querybuilder.QueryBuilder
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.slf4j.LoggerFactory
+import org.sunbird.job.cache.{DataCache, RedisConnect}
+import org.sunbird.job.certgen.domain.Event
+import org.sunbird.job.certgen.task.CertificateGeneratorConfig
+import org.sunbird.job.util.{CassandraUtil, HttpUtil}
+import org.sunbird.job.{BaseProcessFunction, Metrics}
+import scala.collection.JavaConverters._
+
+class CertificateGenerationCompletionProcessorFn(config: CertificateGeneratorConfig, httpUtil: HttpUtil, @transient var cassandraUtil: CassandraUtil = null)
+                                                (implicit val eventTypeInfo: TypeInformation[Event]) extends BaseProcessFunction[Event, String](config) {
+
+  private[this] val logger = LoggerFactory.getLogger(classOf[CertificateGenerationCompletionProcessorFn])
+  private var dataCache: DataCache = _
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+    val redisConnect = new RedisConnect(config)
+    dataCache = new DataCache(config, redisConnect, 0, List())
+    dataCache.init()
+    cassandraUtil = new CassandraUtil(config.dbHost, config.dbPort)
+    logger.info("CertificateGenerationCompletionProcessorFn: Redis connection initialized")
+  }
+
+  override def close(): Unit = {
+    if (dataCache != null) {
+      dataCache.close()
+    }
+    super.close()
+    cassandraUtil.close()
+  }
+
+  override def metricsList(): List[String] = {
+    List(
+      config.totalEventsCount,
+      config.successEventCount,
+      config.failedEventCount,
+      config.skippedEventCount
+    )
+  }
+
+  override def processElement(event: Event,
+                              context: ProcessFunction[Event, String]#Context,
+                              metrics: Metrics): Unit = {
+    metrics.incCounter(config.totalEventsCount)
+    try {
+      val eData = event.getMap().get(config.eData).asInstanceOf[scala.collection.immutable.Map[String, Any]]
+      val usrId: String = eData.get(config.userId) match {
+        case Some(value) => value.asInstanceOf[String]
+        case None => ""
+      }
+      val related = event.related
+      val primaryFields = Map(config.userId.toLowerCase() -> usrId,
+        config.batchId.toLowerCase -> related.getOrElse(config.batchId, "").asInstanceOf[String],
+        config.courseId.toLowerCase -> related.getOrElse(config.courseId, "").asInstanceOf[String])
+      val records = getIssuedCertificatesFromUserEnrollmentTable(primaryFields)(metrics)
+      records.foreach(row => {
+        val certificates = row.getObject("issued_certificates")
+          .asInstanceOf[java.util.List[java.util.Map[String, String]]]
+        val status = row.getInt("status")
+        val progress = row.getInt("progress")
+        if (certificates != null && !certificates.isEmpty && status == 2 && progress == 2) {
+          val redisKey = s"user:certCount:$usrId"
+          val redisValue = 1.toString
+          val redisUserCertificateCount = dataCache.getStringValue(redisKey)
+          if (redisUserCertificateCount.nonEmpty) {
+            val updatedRedisValue = redisUserCertificateCount.toInt + 1
+            dataCache.setWithRetry(redisKey, updatedRedisValue.toString)
+          } else {
+            dataCache.setWithRetry(redisKey, redisValue)
+          }
+
+        }
+      })
+      logger.info(s"Retrieved issued certificates: $records")
+    } catch {
+      case e: Exception =>
+        metrics.incCounter(config.failedEventCount)
+        logger.error(s"Error persisting certificate generation data to Redis: ${e.getMessage}", e)
+    }
+  }
+
+  private def getIssuedCertificatesFromUserEnrollmentTable(columns: Map[String, AnyRef])(implicit metrics: Metrics) = {
+    logger.info("primary columns {}", columns)
+    val selectWhere = QueryBuilder.select("issued_certificates", "status", "progress")
+      .from(config.dbKeyspace, config.dbEnrollmentTable)
+      .where()
+    columns.map(col => {
+      col._2 match {
+        case value: List[Any] =>
+          selectWhere.and(QueryBuilder.in(col._1, value.asJava))
+        case _ =>
+          selectWhere.and(QueryBuilder.eq(col._1, col._2))
+      }
+    })
+    logger.info("select query {}", selectWhere.toString)
+    cassandraUtil.find(selectWhere.toString).asScala.toList
+  }
+}

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGenerationCompletionProcessorFn.scala
@@ -70,9 +70,9 @@ class CertificateGenerationCompletionProcessorFn(config: CertificateGeneratorCon
           val redisUserCertificateCount = dataCache.getStringValue(redisKey)
           if (redisUserCertificateCount.nonEmpty) {
             val updatedRedisValue = redisUserCertificateCount.toInt + 1
-            dataCache.setWithRetry(redisKey, updatedRedisValue.toString)
+            dataCache.setWithRetryAndTTL(redisKey, updatedRedisValue.toString)
           } else {
-            dataCache.setWithRetry(redisKey, redisValue)
+            dataCache.setWithRetryAndTTL(redisKey, redisValue)
           }
 
         }

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
@@ -77,6 +77,7 @@ class CertificateGeneratorFunction  (config: CertificateGeneratorConfig, httpUti
         logger.info(s"Certificate already issued for: ${event.eData.getOrElse("userId", "")} ${event.related}")
       }
       metrics.incCounter(config.successEventCount)
+      context.output(config.certificateGenerationCompletionOutputTag, event)
     } catch {
       case e: Exception =>
         metrics.incCounter(config.failedEventCount)

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
@@ -185,4 +185,5 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
   // Add this to CertificateGeneratorConfig class
   val certificateGenerationCompletionTagName = "post-certificate-generation-completion"
   val certificateGenerationCompletionOutputTag: OutputTag[Event] = OutputTag[Event](certificateGenerationCompletionTagName)
+  val cacheDbId: Int = if(config.hasPath("redis.database.certificateCountCache.id")) config.getInt("redis.database.certificateCountCache.id") else 0
 }

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorConfig.scala
@@ -1,12 +1,13 @@
 package org.sunbird.job.certgen.task
 
 import java.util
-
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.api.scala.createTypeInformation
 import org.apache.flink.streaming.api.scala.OutputTag
 import org.sunbird.job.BaseJobConfig
+import org.sunbird.job.certgen.domain.Event
 import org.sunbird.job.certgen.functions.{NotificationMetaData, UserFeedMetaData}
 
 class CertificateGeneratorConfig(override val config: Config) extends BaseJobConfig(config, "collection-certificate-generator") {
@@ -180,4 +181,8 @@ class CertificateGeneratorConfig(override val config: Config) extends BaseJobCon
   val enableUserNotification: Boolean = if(config.hasPath("enable.user.email.notification")) config.getBoolean("enable.user.email.notification") else true
   val specialEventCertificateName: String = if(config.hasPath("specialEventCertificateName")) config.getString("specialEventCertificateName") else ""
   val eventIssueName = "eventIssueName"
+
+  // Add this to CertificateGeneratorConfig class
+  val certificateGenerationCompletionTagName = "post-certificate-generation-completion"
+  val certificateGenerationCompletionOutputTag: OutputTag[Event] = OutputTag[Event](certificateGenerationCompletionTagName)
 }

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorStreamTask.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/task/CertificateGeneratorStreamTask.scala
@@ -12,7 +12,7 @@ import org.sunbird.incredible.StorageParams
 import org.sunbird.incredible.pojos.exceptions.ServerException
 import org.sunbird.incredible.processor.store.StorageService
 import org.sunbird.job.certgen.domain.Event
-import org.sunbird.job.certgen.functions.{CertificateGeneratorFunction, CreateUserFeedFunction, NotificationMetaData, NotifierFunction, UserFeedMetaData}
+import org.sunbird.job.certgen.functions.{CertificateGenerationCompletionProcessorFn, CertificateGeneratorFunction, CreateUserFeedFunction, NotificationMetaData, NotifierFunction, UserFeedMetaData}
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.util.{FlinkUtil, HttpUtil}
 
@@ -53,6 +53,12 @@ class CertificateGeneratorStreamTask(config: CertificateGeneratorConfig, kafkaCo
       .process(new CreateUserFeedFunction(config, httpUtil))
       .name("user-feed")
       .uid("user-feed")
+      .setParallelism(config.userFeedParallelism)
+
+    processStreamTask.getSideOutput(config.certificateGenerationCompletionOutputTag)
+      .process(new CertificateGenerationCompletionProcessorFn(config, httpUtil))
+      .name("post-certificate-generation-completion")
+      .uid("post-certificate-generation-completion")
       .setParallelism(config.userFeedParallelism)
 
     env.execute(config.jobName)

--- a/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
@@ -68,4 +68,6 @@ class BaseJobConfig(val config: Config, val jobName: String) extends Serializabl
   def getBoolean(key: String, default: Boolean): Boolean = {
     if (config.hasPath(key)) config.getBoolean(key) else default
   }
+
+  val redisTTL: Int =  259200
 }

--- a/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
@@ -225,6 +225,33 @@ class DataCache(val config: BaseJobConfig, val redisConnect: RedisConnect, val d
   def getDBIndex(): Long = {
     this.redisConnection.getDB()
   }
+
+  /**
+   * Retrieves a string value from Redis and returns it directly
+   * @param key Redis key
+   * @return The string value or empty string if not found
+   */
+  def getStringValue(key: String): String = {
+    try {
+      val data = redisConnection.get(key)
+      if (data != null && !data.isEmpty()) {
+        data
+      } else {
+        ""
+      }
+    } catch {
+      case ex: JedisException =>
+        logger.error(s"Exception when retrieving string value from redis for key: $key", ex)
+        close()
+        this.redisConnection = redisConnect.getConnection(dbIndex)
+        val data = redisConnection.get(key)
+        if (data != null && !data.isEmpty()) {
+          data
+        } else {
+          ""
+        }
+    }
+  }
 }
 
 // $COVERAGE-ON$

--- a/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
@@ -252,6 +252,20 @@ class DataCache(val config: BaseJobConfig, val redisConnect: RedisConnect, val d
         }
     }
   }
+
+  def setWithRetryAndTTL(key: String, value: String): Unit = {
+    try {
+      set(key, value);
+      redisConnection.expire(key, config.redisTTL)
+    } catch {
+      case ex@(_: JedisConnectionException | _: JedisException) =>
+        logger.error("Exception when update data to redis cache", ex)
+        close()
+        this.redisConnection = redisConnect.getConnection(dbIndex);
+        set(key, value)
+        redisConnection.expire(key,config.redisTTL)
+    }
+  }
 }
 
 // $COVERAGE-ON$


### PR DESCRIPTION

1. Creating a side output which will call the CertificateGenerationCompletionProcessorFn and this class would be calculating the certificate count by calling the user_enrolment table passing the userid,batchid,courseid .
2. From that we would be checking if issuecertificate is not null ,progress and status should be 2.
3. If the condition is satisfied will check if the key is present in the redis if its there we will increment by 1 else make an entry,
