### PR TITLE
KB-13669 | BE | DEV| Enhancements in Karma Points to remove the Capping of Karma Points

### DIFF
--- a/karma-points-persist-processor/src/main/resources/Karma-points-processor.conf
+++ b/karma-points-persist-processor/src/main/resources/Karma-points-processor.conf
@@ -48,6 +48,7 @@ karmapoints {
    firstEnrolmentQuotaKarmaPoints = 5
    nonAcbpCourseQuota = 4
    eventQuotaKarmaPoints = 5
+   enableCapping = false
 }
 
 redis {

--- a/karma-points-persist-processor/src/main/scala/org/sunbird/job/karmapoints/functions/CourseCompletionProcessorFn.scala
+++ b/karma-points-persist-processor/src/main/scala/org/sunbird/job/karmapoints/functions/CourseCompletionProcessorFn.scala
@@ -152,7 +152,7 @@ class CourseCompletionProcessorFn(config: KarmaPointsProcessorConfig, httpUtil: 
                                     config: KarmaPointsProcessorConfig,
                                     cassandraUtil: CassandraUtil, metrics: Metrics,acbpExpiry:String): Boolean = {
     if(!config.COURSE.equals(contextType) ||
-      (StringUtils.isEmpty(acbpExpiry) && hasReachedNonACBPMonthlyCutOff(userId)(metrics, config, cassandraUtil)) ||
+      (config.enableKarmaPointsCapping && StringUtils.isEmpty(acbpExpiry) && hasReachedNonACBPMonthlyCutOff(userId)(metrics, config, cassandraUtil)) ||
       doesEntryExist(userId, contextType, operationType, contextId)( metrics,config, cassandraUtil))
       return java.lang.Boolean.FALSE
     else

--- a/karma-points-persist-processor/src/main/scala/org/sunbird/job/karmapoints/task/KarmaPointsProcessorConfig.scala
+++ b/karma-points-persist-processor/src/main/scala/org/sunbird/job/karmapoints/task/KarmaPointsProcessorConfig.scala
@@ -167,5 +167,6 @@ class KarmaPointsProcessorConfig(override val config: Config) extends BaseJobCon
   val LANGUAGE_MAP_v1: String = "languageMapV1"
   val COMPLETED_LANGUAGE: String = "completedLanguage"
   val CONTENTS = "contents"
+  val enableKarmaPointsCapping: Boolean = if (config.hasPath("karmapoints.enableCapping")) config.getBoolean("karmapoints.enableCapping") else true
 }
 


### PR DESCRIPTION


1. Previously, karma points for non-ACBP course completions were hard-capped at 4 courses per calendar month (nonAcbpCourseQuota). Users completing more than 4 unique non-ACBP courses in a month would be silently skipped beyond the quota.
